### PR TITLE
Typescript bug: required parameter

### DIFF
--- a/.d.ts
+++ b/.d.ts
@@ -285,8 +285,8 @@ interface formTypes {
     }
 
     rolesSelect: (
-        disabled?: boolean,
         includeBots: boolean,
+        disabled?: boolean,
         themeOptions?: object
     ) => {
         type: string
@@ -296,9 +296,9 @@ interface formTypes {
     }
 
     rolesMultiSelect: (
+        includeBots: boolean,
         disabled?: boolean,
         required?: boolean,
-        includeBots: boolean,
         themeOptions?: object
     ) => {
         type: string


### PR DESCRIPTION
A required parameter cannot follow an optional parameter.

This was causing the compiled typescript to crash on startup after running the app.