### PR TITLE
Adding guild id to the event

### DIFF
--- a/Routes/dashboard.js
+++ b/Routes/dashboard.js
@@ -791,6 +791,7 @@ module.exports = (app, config, themeConfig) => {
             req.DBDEvents.emit("guildSettingsUpdated", {
                 user: req.session.user,
                 changes: { successesForDBDEvent, errorsForDBDEvent },
+                guildId: req.params.guildId,
             })
 
             if (errors[0]) {


### PR DESCRIPTION
it should log which guild id settings has been updated in, so users can do whatever they want with it for example for logging it in that server